### PR TITLE
Use carret constraint for phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "php": ">=7.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.7"
+    "phpunit/phpunit": "^5.7"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
PHPUnit follow semantic version, so using carret constraint will permit update minor versions too. E.g: 5.8.*, 5.9.*, 5.*

https://getcomposer.org/doc/articles/versions.md#caret
